### PR TITLE
add graceful fallback to avoid common errors from occuring

### DIFF
--- a/form-submission-handler.js
+++ b/form-submission-handler.js
@@ -72,9 +72,12 @@ function handleFormSubmit(event) {  // handles form submit withtout any jquery
   }
   */
 
-  if( !validEmail(data.email) ) {   // if email is not valid show error
-    document.getElementById("email-invalid").style.display = "block";
-    return false;
+  if( data.email && !validEmail(data.email) ) {   // if email is not valid show error
+    var invalidEmail = document.getElementById("email-invalid");
+    if (invalidEmail) {
+      invalidEmail.style.display = "block";
+      return false;
+    }
   } else {
     var url = event.target.action;  //
     var xhr = new XMLHttpRequest();
@@ -85,7 +88,10 @@ function handleFormSubmit(event) {  // handles form submit withtout any jquery
         console.log( xhr.status, xhr.statusText )
         console.log(xhr.responseText);
         document.getElementById("gform").style.display = "none"; // hide form
-        document.getElementById("thankyou_message").style.display = "block";
+        var thankYouMessage = document.getElementById("thankyou_message");
+        if (thankYouMessage) {
+          thankYouMessage.style.display = "block";
+        }
         return;
     };
     // url encode form data for sending as post data

--- a/test.html
+++ b/test.html
@@ -49,8 +49,6 @@
     <fieldset class="pure-group">
       <label for="email"><em>Your</em> Email Address:</label>
       <input id="email" name="email" type="email" required value="your.name@email.com" />
-      <span id="email-invalid" style="display:none">
-        Must be a valid email address</span>
     </fieldset>
 
     <!--color-->
@@ -192,11 +190,6 @@
     <input type="hidden" name="hidden" value="this is hidden" />
 
   </form>
-
-  <div style="display:none;" id="thankyou_message">
-    <h2><em>Thanks</em> for filling out our test form!
-      We will get back to you soon!</h2>
-  </div>
 
   <script data-cfasync="false" type="text/javascript" src="form-submission-handler.js"></script>
 


### PR DESCRIPTION
Fixes #203 

Only does the check-email function if such a form element exists, both in the data & only if you have an invalid-email div to select & highlight.

Similarly, after form submission, hides the form but does not completely fail if there is no thankyou message set. Still sends the data and works as expected.

Just added more fault tolerance to the features. These are some of the more common errors people get when trying to use the form in a generic way.