### PR TITLE
only run the xhr request once by disabling form buttons

### DIFF
--- a/form-submission-handler.js
+++ b/form-submission-handler.js
@@ -62,7 +62,7 @@ function getFormData() {
   return data;
 }
 
-function handleFormSubmit(event) {  // handles form submit withtout any jquery
+function handleFormSubmit(event) {  // handles form submit without any jquery
   event.preventDefault();           // we are submitting via xhr below
   var data = getFormData();         // get the values submitted in the form
 
@@ -79,6 +79,7 @@ function handleFormSubmit(event) {  // handles form submit withtout any jquery
       return false;
     }
   } else {
+    disableAllButtons(event.target);
     var url = event.target.action;  //
     var xhr = new XMLHttpRequest();
     xhr.open('POST', url);
@@ -108,3 +109,10 @@ function loaded() {
   form.addEventListener("submit", handleFormSubmit, false);
 };
 document.addEventListener("DOMContentLoaded", loaded, false);
+
+function disableAllButtons(form) {
+  var buttons = form.querySelectorAll("button");
+  for (var i = 0; i < buttons.length; i++) {
+    buttons[i].disabled = true;
+  }
+}


### PR DESCRIPTION
When a user hits submit, we want to cancel any further listeners from getting triggered. A simple way to do this is disable all buttons on the form. I tested this while spam clicking and could not get into a bad state. The button looks decent when this happens. It only disabled the button once we pass validation too, so it does not affect the case where a user accidentally has a wrong email and hits submit that the form no longer works.

thanks @rdhar for your contribution spurring this improvement!