### PR TITLE
use relative links instead of absolute links to all code to fix #222

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -133,9 +133,9 @@ se necesita enviar el formulario usando ***AJAX***.
 Actualiza el `index.html` para incluir el siguiente archivo JavaScript al *final* de tu fila
 (*antes de cerrar el tag `</body>`*)
 
-```js
+```html
 <script data-cfasync="false" type="text/javascript"
-src="https://cdn.rawgit.com/dwyl/learn-to-send-email-via-google-script-html-no-server/master/form-submission-handler.js"></script>
+src="form-submission-handler.js"></script>
 ```
 
 Esto ahora va a mostrar un *message* de "Gracias" cuando el formlario es enviado:
@@ -211,7 +211,7 @@ primer paso, pero podemos hacerlo mejor.
 ![record_data example](https://cloud.githubusercontent.com/assets/194400/10581613/8b4f9ad4-767b-11e5-90cc-962a9d6acc91.png)
 
 Esto grabará los datos recibidos desde el `POST` como una *fila* en la hoja de cálculo.  
-Observa: [**google-apps-script.js**](https://github.com/dwyl/learn-to-send-email-via-google-script-html-no-server/blob/master/google-apps-script.js) para obtener el código completo puedes *copiar y pegar*.
+Observa: [**google-apps-script.js**](google-apps-script.js) para obtener el código completo puedes *copiar y pegar*.
 
 ### 15. Guarda una Nueva Versión y Re-Publicalo
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -150,9 +150,9 @@ Submit 하세요. 보내졌으면 아래와 같이 확인할 수 있습니다:
 
 파일 끝 (*`</body>` 태그 닫기 전)에 다음 JavaScript 파일을 포함하도록 index.html을 업데이트합시다.
 
-```js
+```html
 <script data-cfasync="false" type="text/javascript"
-src="https://cdn.rawgit.com/dwyl/learn-to-send-email-via-google-script-html-no-server/master/form-submission-handler.js"></script>
+src="form-submission-handler.js"></script>
 ```
 
 **경고:** 위의 3단계에서 `TO_ADDRESS` 변수를 설정하지 않은 경우, 메인 form 요소에 `data-email="example@email.net"`를 포함시켜야 됩니다.
@@ -239,7 +239,7 @@ https://developers.google.com/apps-script/reference/mail/mail-app
 ![record_data example](https://cloud.githubusercontent.com/assets/194400/10581613/8b4f9ad4-767b-11e5-90cc-962a9d6acc91.png)
 
 이렇게 하면 `POST`로 받은 데이터가 스프레드시트의 *행(row)*으로 기록됩니다.
-참고: 다음 파일을 이용해 full code를 복붙할 수도 있습니다. [**google-apps-script.js**](https://github.com/dwyl/learn-to-send-email-via-google-script-html-no-server/blob/master/google-apps-script.js)
+참고: 다음 파일을 이용해 full code를 복붙할 수도 있습니다. [**google-apps-script.js**](google-apps-script.js)
 
 ### 15. 새로운 버전 저장하고 재배포하기
 

--- a/README.md
+++ b/README.md
@@ -157,12 +157,11 @@ on your page/site (*avoid "ugly" response page*)
 To *prevent* the page from changing to the `JSON` response/result
 we need to submit the form using ***AJAX***.
 
-Update your `index.html` to include the following JavaScript file at the *end* of your file
+Download [the following Javascript file](form-submission-handler.js) and update your `index.html` to point to it at the *end* of your file
 (*before the closing `</body>` tag)
 
-```js
-<script data-cfasync="false" type="text/javascript"
-src="https://cdn.rawgit.com/dwyl/learn-to-send-email-via-google-script-html-no-server/master/form-submission-handler.js"></script>
+```html
+<script data-cfasync="false" type="text/javascript" src="form-submission-handler.js"></script>
 ```
 
 **Warning:** If you did not set the `TO_ADDRESS` variable in Step 3, then
@@ -244,7 +243,7 @@ the data into a spreadsheet is safer and less prone to data loss.
 ![record_data example](https://cloud.githubusercontent.com/assets/194400/10581613/8b4f9ad4-767b-11e5-90cc-962a9d6acc91.png)
 
 This will record the data received from the `POST` as a *row* in the spreadsheet.  
-See: [**google-apps-script.js**](https://github.com/dwyl/learn-to-send-email-via-google-script-html-no-server/blob/master/google-apps-script.js) for the full code you can *copy-paste*.
+See: [**google-apps-script.js**](google-apps-script.js) for the full code you can *copy-paste*.
 
 ### 15. Save a New Version and Re-Publish it
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
    <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/pure-min.css">
    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
    <!-- Style The Contact Form How Ever You Prefer -->
-   <link rel="stylesheet" href="https://cdn.rawgit.com/dwyl/learn-to-send-email-via-google-script-html-no-server/master/style.css">
+   <link rel="stylesheet" href="style.css">
 
   <form id="gform" method="POST" class="pure-form pure-form-stacked" data-email="example@email.net"
   action="https://script.google.com/macros/s/AKfycbwMxYDrufp73bKdU8gMvxFDdHRuzcR4IKQUB33B7GqwyfyZS04/exec">
@@ -64,9 +64,7 @@
 
   <!-- Submit the Form to Google Using "AJAX" -->
   <script data-cfasync="false" type="text/javascript"
-  src="https://cdn.rawgit.com/dwyl/learn-to-send-email-via-google-script-html-no-server/master/form-submission-handler.js"></script>
-  <!-- <script data-cfasync="false" type="text/javascript"
-  src="/form-submission-handler.js"></script> -->
+  src="form-submission-handler.js"></script>
 <!-- END -->
 
 </body>

--- a/test.html
+++ b/test.html
@@ -12,7 +12,7 @@
 
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/pure-min.css">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-  <link rel="stylesheet" href="https://cdn.rawgit.com/dwyl/learn-to-send-email-via-google-script-html-no-server/master/style.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 
 <body>


### PR DESCRIPTION
When people fork the repo, download the files, or try to use the tutorial to make their own form, they should be using a copy of the JS file so that any breaking changes don't ruin the forms they've created. This is just a tutorial, and we are not looking to make a fixed API with strict versioning, that's overkill here.