### PR TITLE
Fix POST post compliance and multi select

### DIFF
--- a/form-submission-handler.js
+++ b/form-submission-handler.js
@@ -35,25 +35,20 @@
     fields.forEach(function(name){
       var element = elements[name];
       
-      // most form elements just have a single value
-      var data = [element.value];
-
-      // checkboxes are just true or false
-      if (element.type === "checkbox") {
-        data = [element.checked];
+      // singular form elements just have one value
+      formData[name] = element.value;
 
       // when our element has multiple items, get their values
-      } else if (element.length) {
-        data = [];
+      if (element.length) {
+        var data = [];
         for (var i = 0; i < element.length; i++) {
           var item = element.item(i);
           if (item.checked || item.selected) {
             data.push(item.value);
           }
         }
+        formData[name] = data.join(', ');
       }
-
-      formData[name] = data.join(', ');
     });
 
     // add form-specific values into the data

--- a/form-submission-handler.js
+++ b/form-submission-handler.js
@@ -16,9 +16,9 @@
   // get all data in form and return object
   function getFormData() {
     var form = document.getElementById("gform");
-    var elements = form.elements; // all form elements
+    var elements = form.elements;
+
     var fields = Object.keys(elements).filter(function(k) {
-          // the filtering logic is simple, only keep fields that are not the honeypot
           return (elements[k].name !== "honeypot");
     }).map(function(k) {
       if(elements[k].name !== undefined) {
@@ -30,36 +30,39 @@
     }).filter(function(item, pos, self) {
       return self.indexOf(item) == pos && item;
     });
-    var data = {};
-    fields.forEach(function(k){
-      data[k] = elements[k].value;
-      var str = ""; // declare empty string outside of loop to allow
-                    // it to be appended to for each item in the loop
-      if(elements[k].type === "checkbox"){ // special case for Edge's html collection
-        str = str + elements[k].checked + ", "; // take the string and append 
-                                                // the current checked value to 
-                                                // the end of it, along with 
-                                                // a comma and a space
-        data[k] = str.slice(0, -2); // remove the last comma and space 
-                                    // from the  string to make the output 
-                                    // prettier in the spreadsheet
-      }else if(elements[k].length){
-        for(var i = 0; i < elements[k].length; i++){
-          if(elements[k].item(i).checked){
-            str = str + elements[k].item(i).value + ", "; // same as above
-            data[k] = str.slice(0, -2);
+
+    var formData = {};
+    fields.forEach(function(name){
+      var element = elements[name];
+      
+      // most form elements just have a single value
+      var data = [element.value];
+
+      // checkboxes are just true or false
+      if (element.type === "checkbox") {
+        data = [element.checked];
+
+      // when our element has multiple items, get their values
+      } else if (element.length) {
+        data = [];
+        for (var i = 0; i < element.length; i++) {
+          var item = element.item(i);
+          if (item.checked) {
+            data.push(item.value);
           }
         }
       }
+
+      formData[name] = data.join(', ');
     });
 
     // add form-specific values into the data
-    data.formDataNameOrder = JSON.stringify(fields);
-    data.formGoogleSheetName = form.dataset.sheet || "responses"; // default sheet name
-    data.formGoogleSendEmail = form.dataset.email || ""; // no email by default
+    formData.formDataNameOrder = JSON.stringify(fields);
+    formData.formGoogleSheetName = form.dataset.sheet || "responses"; // default sheet name
+    formData.formGoogleSendEmail = form.dataset.email || ""; // no email by default
 
-    console.log(data);
-    return data;
+    console.log(formData);
+    return formData;
   }
 
   function handleFormSubmit(event) {  // handles form submit without any jquery

--- a/form-submission-handler.js
+++ b/form-submission-handler.js
@@ -47,7 +47,7 @@
         data = [];
         for (var i = 0; i < element.length; i++) {
           var item = element.item(i);
-          if (item.checked) {
+          if (item.checked || item.selected) {
             data.push(item.value);
           }
         }

--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -87,7 +87,11 @@ function record_data(e) {
   Logger.log(JSON.stringify(e)); // log the POST data in case we need to debug it
   try {
     var doc     = SpreadsheetApp.getActiveSpreadsheet();
-    var sheet   = doc.getSheetByName(e.parameters.formGoogleSheetName); // select the 'responses' sheet by default
+    
+    // select the 'responses' sheet by default
+    var sheetName = e.parameters.formGoogleSheetName || "responses";
+    var sheet   = doc.getSheetByName(sheetName);
+    
     var headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
     var nextRow = sheet.getLastRow()+1; // get next row
     var row     = [ new Date() ]; // first element in the row should always be a timestamp

--- a/test.html
+++ b/test.html
@@ -104,8 +104,8 @@
     <!--list-->
     <fieldset class="pure-group">
       <label for="list">And Again:</label>
-      <select id="list" name="list" size="5">
-        <option>Javascript</option>
+      <select id="list" name="list" multiple size="5">
+        <option selected>Javascript</option>
         <option>Java</option>
         <option>C++</option>
         <option selected>Python</option>


### PR DESCRIPTION
Code cleanup:
- arrays & joins rather than odd string manipulation
- removed comments that were fixed by cleaner code
- focused comments on the "why" rather than rewriting what the code says

Consistency:
- normal form submissions send checkbox values, not a boolean
- form submission in `test.html` looks the same with or without our parsing

Fixed bugs:
- multi-select options only sent one value before, now they send the list
- if you sent a vanilla POST request, data wouldn't be written to the default google sheet