### PR TITLE
automatically add header fields to spreadsheet fixing #75

### DIFF
--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -84,30 +84,48 @@ function doPost(e) {
  * e is the data received from the POST
  */
 function record_data(e) {
-  Logger.log(JSON.stringify(e)); // log the POST data in case we need to debug it
   try {
-    var doc     = SpreadsheetApp.getActiveSpreadsheet();
+    Logger.log(JSON.stringify(e)); // log the POST data in case we need to debug it
     
     // select the 'responses' sheet by default
+    var doc = SpreadsheetApp.getActiveSpreadsheet();
     var sheetName = e.parameters.formGoogleSheetName || "responses";
-    var sheet   = doc.getSheetByName(sheetName);
+    var sheet = doc.getSheetByName(sheetName);
     
-    var headers = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
-    var nextRow = sheet.getLastRow()+1; // get next row
-    var row     = [ new Date() ]; // first element in the row should always be a timestamp
+    var oldHeader = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+    var newHeader = oldHeader.slice();
+    var fieldsFromForm = getDataColumns(e.parameters);
+    var row = [new Date()]; // first element in the row should always be a timestamp
+    
     // loop through the header columns
-    for (var i = 1; i < headers.length; i++) { // start at 1 to avoid Timestamp column
-      if(headers[i].length > 0) {
-        var values = e.parameters[headers[i]];
-        var output = values[0];
-        for (var j = 1; j < values.length; j++) {
-          output += ', ' + values[j];
-        }
-        row.push(output); // add data to row
+    for (var i = 1; i < oldHeader.length; i++) { // start at 1 to avoid Timestamp column
+      var field = oldHeader[i];
+      var output = getFieldFromData(field, e.parameters);
+      row.push(output);
+      
+      // mark as stored by removing from form fields
+      var formIndex = fieldsFromForm.indexOf(field);
+      if (formIndex > -1) {
+        fieldsFromForm.splice(formIndex, 1);
       }
     }
+    
+    // set any new fields in our form
+    for (var i = 0; i < fieldsFromForm.length; i++) {
+      var field = fieldsFromForm[i];
+      var output = getFieldFromData(field, e.parameters);
+      row.push(output);
+      newHeader.push(field);
+    }
+    
     // more efficient to set values as [][] array than individually
+    var nextRow = sheet.getLastRow() + 1; // get next row
     sheet.getRange(nextRow, 1, 1, row.length).setValues([row]);
+
+    // update header row with any new data
+    if (newHeader.length > oldHeader.length) {
+      sheet.getRange(1, 1, 1, newHeader.length).setValues([newHeader]);
+    }
   }
   catch(error) {
     Logger.log(error);
@@ -116,4 +134,16 @@ function record_data(e) {
     return;
   }
 
+}
+
+function getDataColumns(data) {
+  return Object.keys(data).filter(function(column) {
+    return !(column === 'formDataNameOrder' || column === 'formGoogleSheetName' || column === 'formGoogleSendEmail' || column === 'honeypot');
+  });
+}
+
+function getFieldFromData(field, data) {
+  var values = data[field] || '';
+  var output = values.join ? values.join(', ') : values;
+  return output;
 }


### PR DESCRIPTION
This allows the spreadsheet to be more robust, whereas before empty or missing columns would cause errors that would stop the data from writing to the spreadsheet entirely. Now it just writes an empty string as the default if no form data was found for a given header field.

I also have it adding header fields to the spreadsheet if it finds any new data on the form not yet in the spreadsheet.

The only thing I did not handle was the order - since order is only when you have our clientside JS I think this is OK. The user can always reorder their columns of data, and then it will be in the proper order. I'd rather not have to move more data in the spreadsheet if we don't have to (moving a column requires loading all the data for all rows... no thanks).