### PR TITLE
add a document lock to prevent concurrent writes and solve #104

### DIFF
--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -84,6 +84,9 @@ function doPost(e) {
  * e is the data received from the POST
  */
 function record_data(e) {
+  var lock = LockService.getDocumentLock();
+  lock.waitLock(30000); // hold off up to 30 sec to avoid concurrent writing
+
   Logger.log(JSON.stringify(e)); // log the POST data in case we need to debug it
   try {
     var doc     = SpreadsheetApp.getActiveSpreadsheet();
@@ -113,6 +116,7 @@ function record_data(e) {
     Logger.log(error);
   }
   finally {
+    lock.releaseLock();
     return;
   }
 


### PR DESCRIPTION
I tested this and was able to reproduce not getting some data to save when I would try to submit a form from two different tabs simultaneously. This lock fixes that bug.