### PR TITLE
Remove type declaration on script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,8 +65,7 @@
   </form>
 
   <!-- Submit the Form to Google Using "AJAX" -->
-  <script data-cfasync="false" type="text/javascript"
-  src="form-submission-handler.js"></script>
+  <script data-cfasync="false" src="form-submission-handler.js"></script>
 <!-- END -->
 
 </body>

--- a/test.html
+++ b/test.html
@@ -243,7 +243,7 @@
 
   </form>
 
-  <script data-cfasync="false" type="text/javascript" src="form-submission-handler.js"></script>
+  <script data-cfasync="false" src="form-submission-handler.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Remove type declaration on script tag since it is no longer required for ES5, thanks to @javlonbek-sharipov for the discovery and initial PR!

Had to make a minor change so opening a new PR in place of #267