### PR TITLE
Prevent possible duplicate email sending.

### DIFF
--- a/form-submission-handler.js
+++ b/form-submission-handler.js
@@ -80,12 +80,13 @@
       disableAllButtons(form);
       var url = form.action;
       var xhr = new XMLHttpRequest();
-      xhr.open('POST', url);
+      xhr.open('POST', url, false); // Make the xhr request sync
       // xhr.withCredentials = true;
       xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
       xhr.onreadystatechange = function() {
-          console.log(xhr.status, xhr.statusText);
-          console.log(xhr.responseText);
+        console.log(xhr.status, xhr.statusText);
+        console.log(xhr.responseText);
+        if (xhr.readyState === 4 && xhr.status === 200) {
           form.reset();
           var formElements = form.querySelector(".form-elements")
           if (formElements) {
@@ -96,6 +97,7 @@
             thankYouMessage.style.display = "block";
           }
           return;
+        }
       };
       // url encode form data for sending as post data
       var encoded = Object.keys(data).map(function(k) {


### PR DESCRIPTION
I was getting duplicate email sending so I figured out that if you do the XHR request sync you will only send it once for sure [1]. In addition, I added a conditional statement inside the XHR callback so you only hide the form + show the thank you message when the request is achieved correctly [2].

Reference:
[1] [XMLHttpRequest: xhr.open](https://xhr.spec.whatwg.org/#the-open()-method)
[2] [MDN web docs: xhr.onreadystatechange](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/onreadystatechange)