### PR TITLE
Remove unnecessary form validation for email

### DIFF
--- a/form-submission-handler.js
+++ b/form-submission-handler.js
@@ -1,9 +1,4 @@
 (function() {
-  function validEmail(email) {
-    var re = /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i;
-    return re.test(email);
-  }
-
   function validateHuman(honeypot) {
     if (honeypot) {  //if hidden form filled up
       console.log("Robot Detected!");
@@ -70,39 +65,31 @@
     }
     */
 
-    if( data.email && !validEmail(data.email) ) {   // if email is not valid show error
-      var invalidEmail = form.querySelector(".email-invalid");
-      if (invalidEmail) {
-        invalidEmail.style.display = "block";
-        return false;
-      }
-    } else {
-      disableAllButtons(form);
-      var url = form.action;
-      var xhr = new XMLHttpRequest();
-      xhr.open('POST', url);
-      // xhr.withCredentials = true;
-      xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-      xhr.onreadystatechange = function() {
-          console.log(xhr.status, xhr.statusText);
-          console.log(xhr.responseText);
-          form.reset();
-          var formElements = form.querySelector(".form-elements")
-          if (formElements) {
-            formElements.style.display = "none"; // hide form
-          }
-          var thankYouMessage = form.querySelector(".thankyou_message");
-          if (thankYouMessage) {
-            thankYouMessage.style.display = "block";
-          }
-          return;
-      };
-      // url encode form data for sending as post data
-      var encoded = Object.keys(data).map(function(k) {
-          return encodeURIComponent(k) + "=" + encodeURIComponent(data[k]);
-      }).join('&');
-      xhr.send(encoded);
-    }
+    disableAllButtons(form);
+    var url = form.action;
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', url);
+    // xhr.withCredentials = true;
+    xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+    xhr.onreadystatechange = function() {
+        console.log(xhr.status, xhr.statusText);
+        console.log(xhr.responseText);
+        form.reset();
+        var formElements = form.querySelector(".form-elements")
+        if (formElements) {
+          formElements.style.display = "none"; // hide form
+        }
+        var thankYouMessage = form.querySelector(".thankyou_message");
+        if (thankYouMessage) {
+          thankYouMessage.style.display = "block";
+        }
+        return;
+    };
+    // url encode form data for sending as post data
+    var encoded = Object.keys(data).map(function(k) {
+        return encodeURIComponent(k) + "=" + encodeURIComponent(data[k]);
+    }).join('&');
+    xhr.send(encoded);
   }
   
   function loaded() {

--- a/index.html
+++ b/index.html
@@ -43,8 +43,6 @@
         <label for="email"><em>Your</em> Email Address:</label>
         <input id="email" name="email" type="email" value=""
         required placeholder="your.name@email.com"/>
-        <span class="email-invalid" style="display:none">
-          Must be a valid email address</span>
       </fieldset>
 
       <fieldset class="pure-group">

--- a/test.html
+++ b/test.html
@@ -222,8 +222,6 @@
         <label for="email"><em>Your</em> Email Address:</label>
         <input id="email" name="email" type="email" value=""
         required placeholder="your.name@email.com"/>
-        <span class="email-invalid" style="display:none">
-          Must be a valid email address</span>
       </fieldset>
 
       <fieldset class="pure-group">


### PR DESCRIPTION
The HTML 5 form input type of email already handles
email validation. There are cases that are allowed by
HTML5 (e.g., "a@a") which our form used to detect
and notify the user. Since these are less likely to
happen, and the logic is still not fool-proof, simplify
the code and assumptions made therein to be
more generalizable and thus more robust. This is
supported in all modern browsers, and I tested
this also in Edge to verify that it works there, too.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email