### PR TITLE
Restrict web app file access

### DIFF
--- a/google-apps-script.js
+++ b/google-apps-script.js
@@ -7,6 +7,11 @@
 // if you want to store your email server-side (hidden), uncomment the next line
 // var TO_ADDRESS = "example@email.net";
 
+/**
+ * Give access to the current spreadsheet only
+ * @OnlyCurrentDoc
+ */
+
 // spit out all the keys/values from the form in HTML for email
 // uses an array of keys if provided or the object to determine field order
 function formatMailBody(obj, order) {


### PR DESCRIPTION
When deploying a web app, the authorization dialog requests access to _all of the user's documents_. This is a very broad permission, especially since anyone can POST to the app. 

I added the  `@OnlyCurrentDoc` annotation to restrict access to the current file only.

See [documentation here](https://developers.google.com/apps-script/guides/services/authorization#manual_authorization_scopes_forand).

**Before**
![before](https://github.com/user-attachments/assets/30d7fa6e-44af-43ea-a932-e19c5ee344bd)
**After**:
![after](https://github.com/user-attachments/assets/b753ef84-c315-4581-b555-6596221cb92c)
